### PR TITLE
added support for arn value in app section in config

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -30,7 +30,7 @@ func init() {
 		"Write credentials to this file instead of the default ($HOME/.aws/credentials)",
 	)
 	err := viper.BindPFlag("global.credentials-path", cmdGet.Flags().Lookup("write-to-file"))
-	 if err != nil {
+	if err != nil {
 		log.Fatalf(color.RedString("Error binding flag global.credentials-path: %v"), err)
 	}
 }
@@ -116,10 +116,12 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 			log.Fatalf(color.RedString("Could not get provider type for provider '%s'"), provider)
 		}
 
+		pArn := viper.GetString(fmt.Sprintf("apps.%s.arn", app))
+
 		duration := sessionDuration(app, provider)
 
 		if pType == "onelogin" {
-			creds, err := onelogin.Get(app, provider, duration)
+			creds, err := onelogin.Get(app, provider, pArn, duration)
 			if err != nil {
 				log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 			}

--- a/okta/get.go
+++ b/okta/get.go
@@ -146,7 +146,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 		return nil, fmt.Errorf("Error launching app: %v", err)
 	}
 
-	arn, err := saml.Get(*samlAssertion)
+	arn, err := saml.Get(*samlAssertion, "")
 	if err != nil {
 		return nil, err
 	}

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -35,7 +35,7 @@ var (
 
 // Get gets temporary credentials for the given app.
 // TODO Move AWS logic outside this function.
-func Get(app, provider string, duration int64) (*aws.Credentials, error) {
+func Get(app, provider, pArn string, duration int64) (*aws.Credentials, error) {
 	// Read config
 	p, err := config.GetOneLoginProvider(provider)
 	if err != nil {
@@ -175,7 +175,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 		rData = rSaml.Data
 	}
 
-	arn, err := saml.Get(rData)
+	arn, err := saml.Get(rData, pArn)
 	if err != nil {
 		return nil, err
 	}

--- a/saml/saml.go
+++ b/saml/saml.go
@@ -19,7 +19,7 @@ type ARN struct {
 	Name     string
 }
 
-func Get(data string) (a ARN, err error) {
+func Get(data, pArn string) (a ARN, err error) {
 	samlBody, err := decode(data)
 	if err != nil {
 		return
@@ -31,7 +31,7 @@ func Get(data string) (a ARN, err error) {
 		return
 	}
 
-	arns := extractArns(x.Assertion.AttributeStatement.Attributes)
+	arns := extractArns(x.Assertion.AttributeStatement.Attributes, pArn)
 
 	switch len(arns) {
 	case 0:
@@ -55,62 +55,94 @@ func decode(in string) (b []byte, err error) {
 	return base64.StdEncoding.DecodeString(in)
 }
 
-func extractArns(attrs []saml.Attribute) (arns []ARN) {
+func extractArns(attrs []saml.Attribute, pArn string) (arns []ARN) {
 	// check for human readable ARN strings in config
 	accounts := viper.GetStringMap("global.accounts")
 	arns = make([]ARN, 0)
 
-	for _, attr := range attrs {
-		if attr.Name == "https://aws.amazon.com/SAML/Attributes/Role" {
-			for _, av := range attr.Values {
-				// Value is empty
-				if len(av.Value) == 0 {
-					return
-				}
-
-				// Verify we have one of the following formats:
-				// 1. arn:aws:iam::xxxxxxxxxxxx:role/MyRole,arn:aws:iam::xxxxxxxxxxxx:saml-provider/MyProvider
-				// 2. arn:aws:iam::xxxxxxxxxxxx:saml-provider/MyProvider,arn:aws:iam::xxxxxxxxxxxx:role/MyRole
-				// Error otherwise.
-				components := strings.Split(strings.TrimSpace(av.Value), ",")
-				if len(components) != 2 {
-					// Wrong number of components - move on
-					continue
-				}
-
-				// Prepare patterns
-				role := regexp.MustCompile(`^arn:aws:iam::(?P<Id>\d+):(?P<Name>role\/\S+)$`)
-				idp := regexp.MustCompile(`^arn:aws:iam::\d+:saml-provider\/\S+$`)
-				arn := ARN{}
-
-				if role.MatchString(components[0]) && idp.MatchString(components[1]) {
-					// First component is role
-					arn = ARN{components[0], components[1], ""}
-				} else if role.MatchString(components[1]) && idp.MatchString(components[0]) {
-					// First component is IdP
-					arn = ARN{components[1], components[0], ""}
-				} else {
-					continue
-				}
-
-				// Look up the human friendly name, if available
-				if len(accounts) > 0 {
-					ids := role.FindStringSubmatch(arn.Role)
-
-					// if the regex matches we should have 3 entries from the regex match
-					// 1) the matching string
-					// 2) the match for Id
-					// 3) the match for Name
-					// we want to match the Id to any accounts/roles in our config
-					if len(ids) == 3 && accounts[ids[1]] != "" && accounts[ids[1]] != nil {
-						arn.Name = fmt.Sprintf("%s - %s", accounts[ids[1]].(string), ids[2])
+	// This duplicates a lot of the code from the original loop, but this was
+	// mostly a test to make sure it would work.
+	if pArn != "" {
+		for _, attr := range attrs {
+			if attr.Name == "https://aws.amazon.com/SAML/Attributes/Role" {
+				for _, av := range attr.Values {
+					// Value is empty
+					if len(av.Value) == 0 {
+						return
 					}
+					components := strings.Split(strings.TrimSpace(av.Value), ",")
+					if len(components) != 2 {
+						// Wrong number of components - move on
+						continue
+					}
+
+					arn := ARN{}
+
+					if components[0] == pArn {
+						arn = ARN{components[0], components[1], ""}
+					} else if components[1] == pArn {
+						arn = ARN{components[1], components[0], ""}
+					} else {
+						continue
+					}
+					arns = append(arns, arn)
+
+				}
+			}
+		}
+	} else {
+		for _, attr := range attrs {
+			if attr.Name == "https://aws.amazon.com/SAML/Attributes/Role" {
+				for _, av := range attr.Values {
+					// Value is empty
+					if len(av.Value) == 0 {
+						return
+					}
+
+					// Verify we have one of the following formats:
+					// 1. arn:aws:iam::xxxxxxxxxxxx:role/MyRole,arn:aws:iam::xxxxxxxxxxxx:saml-provider/MyProvider
+					// 2. arn:aws:iam::xxxxxxxxxxxx:saml-provider/MyProvider,arn:aws:iam::xxxxxxxxxxxx:role/MyRole
+					// Error otherwise.
+					components := strings.Split(strings.TrimSpace(av.Value), ",")
+					if len(components) != 2 {
+						// Wrong number of components - move on
+						continue
+					}
+
+					// Prepare patterns
+					role := regexp.MustCompile(`^arn:aws:iam::(?P<Id>\d+):(?P<Name>role\/\S+)$`)
+					idp := regexp.MustCompile(`^arn:aws:iam::\d+:saml-provider\/\S+$`)
+					arn := ARN{}
+
+					if role.MatchString(components[0]) && idp.MatchString(components[1]) {
+						// First component is role
+						arn = ARN{components[0], components[1], ""}
+					} else if role.MatchString(components[1]) && idp.MatchString(components[0]) {
+						// First component is IdP
+						arn = ARN{components[1], components[0], ""}
+					} else {
+						continue
+					}
+
+					// Look up the human friendly name, if available
+					if len(accounts) > 0 {
+						ids := role.FindStringSubmatch(arn.Role)
+
+						// if the regex matches we should have 3 entries from the regex match
+						// 1) the matching string
+						// 2) the match for Id
+						// 3) the match for Name
+						// we want to match the Id to any accounts/roles in our config
+						if len(ids) == 3 && accounts[ids[1]] != "" && accounts[ids[1]] != nil {
+							arn.Name = fmt.Sprintf("%s - %s", accounts[ids[1]].(string), ids[2])
+						}
+					}
+
+					arns = append(arns, arn)
 				}
 
-				arns = append(arns, arn)
+				return
 			}
-
-			return
 		}
 	}
 


### PR DESCRIPTION
Adding support for specifying an arn to use per "app" so that you don't have to always choose from the list.

Configuration change to `clisso.yaml`:
```
apps:
  prod:
    app-id: "123456"
    principal-arn: arn:aws:iam::XXXXXXXXXXXX:policy/OneLoginListRoles
    provider: onelogin-provider
    role-arn: arn:aws:iam::XXXXXXXXXXXX:saml-provider/OneLogin
    duration: 28800
    arn: arn:aws:iam::XXXXXXXXXXXX:role/SRE
```