### PR TITLE
Add support for preferred arn per app

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -30,7 +30,7 @@ func init() {
 		"Write credentials to this file instead of the default ($HOME/.aws/credentials)",
 	)
 	err := viper.BindPFlag("global.credentials-path", cmdGet.Flags().Lookup("write-to-file"))
-	 if err != nil {
+	if err != nil {
 		log.Fatalf(color.RedString("Error binding flag global.credentials-path: %v"), err)
 	}
 }
@@ -116,10 +116,14 @@ If no app is specified, the selected app (if configured) will be assumed.`,
 			log.Fatalf(color.RedString("Could not get provider type for provider '%s'"), provider)
 		}
 
+		// allow preferred "arn" to be specified in the config file for each app
+		// if this is not specified the value will be empty ("")
+		pArn := viper.GetString(fmt.Sprintf("apps.%s.arn", app))
+
 		duration := sessionDuration(app, provider)
 
 		if pType == "onelogin" {
-			creds, err := onelogin.Get(app, provider, duration)
+			creds, err := onelogin.Get(app, provider, pArn, duration)
 			if err != nil {
 				log.Fatal(color.RedString("Could not get temporary credentials: "), err)
 			}

--- a/okta/get.go
+++ b/okta/get.go
@@ -146,7 +146,8 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 		return nil, fmt.Errorf("Error launching app: %v", err)
 	}
 
-	arn, err := saml.Get(*samlAssertion)
+	// Passing in "" to the saml.Get since okta does not support the pArn value (yet)
+	arn, err := saml.Get(*samlAssertion, "")
 	if err != nil {
 		return nil, err
 	}

--- a/onelogin/get.go
+++ b/onelogin/get.go
@@ -35,7 +35,7 @@ var (
 
 // Get gets temporary credentials for the given app.
 // TODO Move AWS logic outside this function.
-func Get(app, provider string, duration int64) (*aws.Credentials, error) {
+func Get(app, provider, pArn string, duration int64) (*aws.Credentials, error) {
 	// Read config
 	p, err := config.GetOneLoginProvider(provider)
 	if err != nil {
@@ -175,7 +175,7 @@ func Get(app, provider string, duration int64) (*aws.Credentials, error) {
 		rData = rSaml.Data
 	}
 
-	arn, err := saml.Get(rData)
+	arn, err := saml.Get(rData, pArn)
 	if err != nil {
 		return nil, err
 	}

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -4,6 +4,7 @@ apps:
     principal-arn: arn:aws:iam::123456789012:saml-provider/OneLoginDev
     provider: sample-onelogin-provider
     role-arn: arn:aws:iam::123456789012:role/OneLoginDev-SSO
+    arn: arn:aws:iam::012345678012:role/Dev
   sample-app-2:
     principal-arn: arn:aws:iam::123456789012:saml-provider/Okta
     provider: sample-okta-provider


### PR DESCRIPTION
Adding support for specifying an arn to use per "app" so that you don't have to always choose from the list.

Configuration change to `clisso.yaml`:
```
apps:
  prod:
    app-id: "123456"
    principal-arn: arn:aws:iam::XXXXXXXXXXXX:policy/OneLoginListRoles
    provider: onelogin-provider
    role-arn: arn:aws:iam::XXXXXXXXXXXX:saml-provider/OneLogin
    duration: 28800
    arn: arn:aws:iam::XXXXXXXXXXXX:role/SRE
```